### PR TITLE
build: bump Django to 6.0.7 and GitPython to 3.1.51

### DIFF
--- a/.github/workflows/ruff.yaml
+++ b/.github/workflows/ruff.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Ruff Check
         if: steps.changed.outputs.files != ''
-        uses: astral-sh/ruff-action@v4.0.0
+        uses: astral-sh/ruff-action@v4.1.0
         with:
           src: ${{ steps.changed.outputs.files }}
           args: >

--- a/prek.toml
+++ b/prek.toml
@@ -39,7 +39,7 @@ hooks = [
 
 [[repos]]
 repo = "https://github.com/astral-sh/ruff-pre-commit"
-rev = "v0.15.20"
+rev = "v0.15.21"
 hooks = [
   { id = "ruff", args = ["--fix", "--exit-non-zero-on-fix"] },
   { id = "ruff-format", args = ["--check"] },
@@ -56,7 +56,7 @@ exclude = '\.(css\.map|json|js\.map|lock|min\.css\.map|min\.js|po|pyc)$|shCore.j
 
 [[repos]]
 repo = "https://github.com/astral-sh/uv-pre-commit"
-rev = "0.11.25"
+rev = "0.11.28"
 hooks = [
   { id = "uv-lock" },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,13 +6,13 @@ version = "1.8.0"
 requires-python = ">=3.12,<4.0"
 
 dependencies = [
-  "Django>=5.2.14,<6.0",
+  "Django>=6.0.7,<7.0",
   "psycopg2-binary>=2.9.11",
   "django-braces>=1.15.0"
 ]
 
 [project.optional-dependencies]
-git = ["GitPython>=3.1.27"]
+git = ["GitPython>=3.1.51"]
 celery_results = ["django-celery-results>=2.6.0"]
 
 [tool.commitizen]

--- a/uv.lock
+++ b/uv.lock
@@ -360,16 +360,16 @@ wheels = [
 
 [[package]]
 name = "django"
-version = "5.2.16"
+version = "6.0.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "asgiref" },
     { name = "sqlparse" },
     { name = "tzdata", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/26/889449d521ae508b26de715954faecd8bcf3f740affb81b2d146a83b42a5/django-5.2.16.tar.gz", hash = "sha256:59ea02020c3136fce14bef0bbece21a10a4febef5eed1c51c22ae468efa22200", size = 10890894, upload-time = "2026-07-07T13:52:17.005Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/55/664f24ff81c9ea19cb7dfc851afeae1f3c2390c7aee01d4ded68b5c1580d/django-6.0.7.tar.gz", hash = "sha256:2998503fc083124fb58037084bfa00de323c7c743f05f1b4284e77bff0ab8890", size = 10921299, upload-time = "2026-07-07T13:51:26.485Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4e/13/1e5e3e4c15dcecb04281b3cb2a46a4670e1cef131068e202f6040df19224/django-5.2.16-py3-none-any.whl", hash = "sha256:04f354bf9d807a86ad1a8392fe3808d362358a8eafc322848e0e43e59b24371d", size = 8311943, upload-time = "2026-07-07T13:52:11.223Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/ec/1ce5334b6a2c52ce619c23a0be8d366a57a0e080ebb2d88266e5c849157c/django-6.0.7-py3-none-any.whl", hash = "sha256:a037427c2288443a8c02a1b02295a31c239663aa682bc50b1976afb7cf6a769e", size = 8373344, upload-time = "2026-07-07T13:51:20.007Z" },
 ]
 
 [[package]]
@@ -412,7 +412,7 @@ wheels = [
 
 [[package]]
 name = "django-diagnostic"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -460,10 +460,10 @@ tests = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=5.2.14,<6.0" },
+    { name = "django", specifier = ">=6.0.7,<7.0" },
     { name = "django-braces", specifier = ">=1.15.0" },
     { name = "django-celery-results", marker = "extra == 'celery-results'", specifier = ">=2.6.0" },
-    { name = "gitpython", marker = "extra == 'git'", specifier = ">=3.1.27" },
+    { name = "gitpython", marker = "extra == 'git'", specifier = ">=3.1.51" },
     { name = "psycopg2-binary", specifier = ">=2.9.11" },
 ]
 provides-extras = ["git", "celery-results"]
@@ -650,14 +650,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.50"
+version = "3.1.51"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/30/a8a0c15f9480dc91b5b7f11ebd26105e5f80898d7ff02da197fef35d8395/gitpython-3.1.51.tar.gz", hash = "sha256:22c9c94bb6b0b9f3c7157c684fece45a414cea204586b600beae6cd4570dcd6d", size = 223519, upload-time = "2026-07-12T13:40:07.922Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/11/1232bb1ba52a230f20ff08e1b3df7cd9d43a71b61cc0a1c37941064fe4c7/gitpython-3.1.51-py3-none-any.whl", hash = "sha256:d5b29685708f3c80a56db040b665bfd69492c8e150b5848532af8013b686c5a4", size = 215246, upload-time = "2026-07-12T13:40:06.43Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Django>=6.0.7,<7.0 (was <6.0), GitPython>=3.1.51 in the git extra (was >=3.1.27) - clears the flagged RHDA vulnerabilities in both
- prek autoupdate: ruff-pre-commit v0.15.20 -> v0.15.21, uv-pre-commit 0.11.25 -> 0.11.28
- Bump astral-sh/ruff-action v4.0.0 -> v4.1.0 in ruff.yaml (matches open Dependabot PR #43)

## Test plan
- [x] `uv sync --all-groups` resolves cleanly against Django 6.0.7
- [x] Full test suite passes (6/6) against Django 6.0.7
- [x] `prek run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)